### PR TITLE
Update make apply rules to support configurable cluster sizes

### DIFF
--- a/kubeflow/Makefile
+++ b/kubeflow/Makefile
@@ -51,6 +51,14 @@ set-values:
 
 	kpt cfg set ./upstream/manifests/gcp/v2/cnrm/cluster/custom name <YOUR_KF_NAME>
 	kpt cfg set ./upstream/manifests/gcp/v2/cnrm/cluster/custom location <REGION OR ZONE>
+	kpt cfg create-setter ./upstream/manifests/gcp/v2/cnrm/cluster/custom default-nodepool-size default-nodepool-size --type integer
+	kpt cfg set ./upstream/manifests/gcp/v2/cnrm/cluster/custom default-nodepool-size <DEFAULT_NODEPOOL_MAX_SIZE>
+	kpt cfg create-setter ./upstream/manifests/gcp/v2/cnrm/cluster/custom cpu-worker-nodepool-max-size cpu-worker-nodepool-max-size --type integer
+	kpt cfg set ./upstream/manifests/gcp/v2/cnrm/cluster/custom cpu-worker-nodepool-max-size <CPU_WORKER_NODEPOOL_MAX_SIZE>
+	kpt cfg create-setter ./upstream/manifests/gcp/v2/cnrm/cluster/custom gpu-t4-worker-nodepool-max-size gpu-t4-worker-nodepool-max-size --type integer
+	kpt cfg set ./upstream/manifests/gcp/v2/cnrm/cluster/custom gpu-t4-worker-nodepool-max-size <GPU_WORKER_NODEPOOL_MAX_SIZE>
+	kpt cfg create-setter ./upstream/manifests/gcp/v2/cnrm/cluster/custom gpu-nvidia-tesla-t4-limit gpu-nvidia-tesla-t4-limit --type integer
+	kpt cfg set ./upstream/manifests/gcp/v2/cnrm/cluster/custom gpu-nvidia-tesla-t4-limit <NVIDIA_TESLA_T4_GPU_MAX_LIMIT>
 
 	kpt cfg set ./upstream/manifests/stacks/gcp name <YOUR_KF_NAME>
 	kpt cfg set ./upstream/manifests/stacks/gcp gcloud.core.project <PROJECT_TO_DEPLOY_IN>
@@ -136,7 +144,7 @@ hydrate-kubeflow:
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/namespaces  ${KF_DIR}/namespaces
 
 	mkdir -p $(BUILD_DIR)/application
-	kustomize build --load_restrictor none -o $(BUILD_DIR)/application $(KF_DIR)/application
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/application $(KF_DIR)/application/custom
 
 	mkdir -p $(BUILD_DIR)/knative
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/knative $(KF_DIR)/knative
@@ -148,7 +156,7 @@ hydrate-kubeflow:
 	mkdir -p $(BUILD_DIR)/cert-manager-kube-system-resources
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/cert-manager-kube-system-resources $(KF_DIR)/cert-manager-kube-system-resources
 	mkdir -p $(BUILD_DIR)/cloud-endpoints
-	kustomize build --load_restrictor none -o $(BUILD_DIR)/cloud-endpoints $(KF_DIR)/cloud-endpoints
+	kustomize build --load_restrictor none -o $(BUILD_DIR)/cloud-endpoints $(KF_DIR)/cloud-endpoints/custom
 	mkdir -p $(BUILD_DIR)/iap-ingress
 	kustomize build --load_restrictor none -o $(BUILD_DIR)/iap-ingress $(KF_DIR)/iap-ingress
 	mkdir -p $(BUILD_DIR)/kubeflow-apps

--- a/kubeflow/instance/kustomize/application/custom/kustomization.yaml
+++ b/kubeflow/instance/kustomize/application/custom/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../upstream/manifests/application/v3 # {"$kpt-set":"application-v3"}
+patchesStrategicMerge:
+- stateful-set-patch.yaml

--- a/kubeflow/instance/kustomize/application/custom/stateful-set-patch.yaml
+++ b/kubeflow/instance/kustomize/application/custom/stateful-set-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: stateful-set
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool

--- a/kubeflow/instance/kustomize/cloud-endpoints/custom/deployment-patch.yaml
+++ b/kubeflow/instance/kustomize/cloud-endpoints/custom/deployment-patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cloud-endpoints-controller
+spec:
+  template:
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-nodepool: default-pool

--- a/kubeflow/instance/kustomize/cloud-endpoints/custom/kustomization.yaml
+++ b/kubeflow/instance/kustomize/cloud-endpoints/custom/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../../../upstream/manifests/gcp/cloud-endpoints/overlays/application # {"$kpt-set":"gcp-cloud-endpoints-overlays-application"}
+patchesStrategicMerge:
+- ../service-accounts.yaml
+- deployment-patch.yaml


### PR DESCRIPTION
- Added node pool node selector to ensure all control plane pods are scheduled on default node pool.
- Made cluster size, node pool size and cluster gpu limit configurable.